### PR TITLE
Fix typo and ensure the original url is passed to next.

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -1,6 +1,6 @@
 ## Usage
 
-This library recursively calls [needle's](https://github.com/tomas/needle#needlemethod-url-data-options-callback--20x) `.get` method as long as the user-provide `next()` function returns a string (the next url to get). See [an example](#example).
+This library recursively calls [needle's](https://github.com/tomas/needle#needlemethod-url-data-options-callback--20x) `.get` method as long as the user-provided `next()` function returns a string (the next url to get). See [an example](#example).
 
 **Example**
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = async function(url, options, next) {
 
   const opts = Object.assign({}, options);
   const acc = { url, options: opts, pages: [], hrefs: [] };
+  const orig = url;
   let prev;
   let res;
 
@@ -21,7 +22,7 @@ module.exports = async function(url, options, next) {
     prev = url;
     acc.hrefs.push(url);
     res = await needle('get', url, opts);
-    url = await next(url, res, acc);
+    url = await next(orig, res, acc);
     acc.pages.push(res);
   }
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = async function(url, options, next) {
 
   const opts = Object.assign({}, options);
   const acc = { url, options: opts, pages: [], hrefs: [] };
-  const orig = url;
   let prev;
   let res;
 
@@ -22,7 +21,7 @@ module.exports = async function(url, options, next) {
     prev = url;
     acc.hrefs.push(url);
     res = await needle('get', url, opts);
-    url = await next(orig, res, acc);
+    url = await next(acc.url, res, acc);
     acc.pages.push(res);
   }
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = async function(url, options, next) {
   while (url && typeof url === 'string' && prev !== url) {
     prev = url;
     acc.hrefs.push(url);
-    res = await needle('get', url, opts);
+    res = await needle('get', url, null, opts);
     url = await next(acc.url, res, acc);
     acc.pages.push(res);
   }

--- a/test.js
+++ b/test.js
@@ -27,4 +27,17 @@ describe('paged-request', function() {
       })
       .catch(cb);
   });
+
+  it('should keep the history of `hrefs`', function(cb) {
+    request('https://www.smashingmagazine.com/category/css', {}, next(3))
+      .then(acc => {
+        assert.deepEqual(acc.hrefs, [
+          'https://www.smashingmagazine.com/category/css',
+          'https://www.smashingmagazine.com/category/css/page/2/',
+          'https://www.smashingmagazine.com/category/css/page/3/'
+        ]);
+        cb();
+      })
+      .catch(cb);
+  });
 });


### PR DESCRIPTION
This PR does the following:

- fix a typo in the `.verb.md` file
- add a test to ensures `next` will be called more than once.
- keep the original `url` and pass that to `next` as described in the docs.