### PR TITLE
Upgrade axios for  CVE-2021-3749

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": ">=0.22.0"
   }
 }


### PR DESCRIPTION
### Summary
Upgrade axios to fix CVE-2021-3749

### Testing
* `npm install && npm test` tests pass
* no breaking changes between axios versions `0.21.1` and `0.22.0` according to release notes: https://github.com/axios/axios/releases